### PR TITLE
Add link to author's copy of “Parsing with Zippers” paper.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ Sebastian Graf, Simon Peyton Jones, Ryan G. Scott
 
 **Parsing with Zippers (Functional Pearl)**  
 Pierce Darragh, Michael D. Adams  
-([artifact](https://github.com/pdarragh/parsing-with-zippers-paper-artifact))
+([pdf](https://michaeldadams.org/papers/parsing-with-zippers/parsing-with-zippers.pdf)) ([artifact](https://github.com/pdarragh/parsing-with-zippers-paper-artifact))
 
 **Program Sketching with Live Bidirectional Evaluation**  
 Justin Lubin, Nick Collins, Cyrus Omar, Ravi Chugh  


### PR DESCRIPTION
Add link to the recently released author's copy of the [paper via personal homepage](https://michaeldadams.org/papers/parsing-with-zippers/).
